### PR TITLE
fix type declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,11 @@ declare class WasmModule {
   destroy(): void;
 }
 
-export const ready: Promise<undefined>;
-export function parseWat(filename: string, buffer: string | Uint8Array, options?: WasmFeatures): WasmModule;
-export function readWasm(buffer: Uint8Array, options: ReadWasmOptions & WasmFeatures): WasmModule;
+interface WabtModule {
+  ready: Promise<undefined>
+  parseWat(filename: string, buffer: string | Uint8Array, options?: WasmFeatures): WasmModule;
+  readWasm(buffer: Uint8Array, options: ReadWasmOptions & WasmFeatures): WasmModule;
+}
+
+declare function wabt(): WabtModule
+export = wabt


### PR DESCRIPTION
Hi, in order to use types, I had to make the following changes to the type declaration file.

The issue with the current version is "require" imports the functions as a module, when instead it needs to first be called as a function according to the repo's usage section.