### PR TITLE
Expose all wabt features

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,8 @@ interface WasmFeatures { // see: https://github.com/WebAssembly/wabt/blob/main/s
   simd?: boolean;
   /** Threading support. */
   threads?: boolean;
+  /** Typed function references. */
+  function_references?: boolean;
   /** Multi-value. */
   multi_value?: boolean;
   /** Tail-call support. */
@@ -22,8 +24,16 @@ interface WasmFeatures { // see: https://github.com/WebAssembly/wabt/blob/main/s
   reference_types?: boolean;
   /** Custom annotation syntax. */
   annotations?: boolean;
+  /** Code metadata. */
+  code_metadata?: boolean;
   /** Garbage collection. */
   gc?: boolean;
+  /** 64-bit memory */
+  memory64?: boolean;
+  /** Extended constant expressions. */
+  extended_const?: boolean;
+  /** Relaxed SIMD. */
+  relaxed_simd?: boolean;
 }
 
 /** Options modifying the behavior of `readWasm`. */

--- a/tests/index.js
+++ b/tests/index.js
@@ -25,7 +25,6 @@ require("..")().then(wabt => {
     test.doesNotThrow(function() {
       mod = wabt.readWasm(buffer, {
         readDebugNames: true,
-        simd: true,
       });
     });
     test.ok(mod && typeof mod.toBinary === "function", "should return a module");
@@ -84,9 +83,7 @@ require("..")().then(wabt => {
     var str = fs.readFileSync(__dirname + "/assembly/module-features.wat").toString();
     var mod;
     test.doesNotThrow(function() {
-      mod = wabt.parseWat("module-features.wat", str, {
-        simd: true,
-      });
+      mod = wabt.parseWat("module-features.wat", str);
     });
     test.ok(mod && typeof mod.toBinary === "function", "should return a module");
     test.doesNotThrow(function() {


### PR DESCRIPTION
With recent wabt changes, some features are enabled by default and no longer need to be explicitly selected (same as in native wabt).