### PR TITLE
Add new `check` option to `ReadWasmOptions`, with test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ API
 
    * **readDebugNames**: `boolean`<br />
      Reads textual names from the name section.
+   * **check:** `boolean`<br/>
+     Check for invalid modules (default: true).
 
 * **ToTextOptions**<br />
   Options modifying the behavior of `WasmModule#toText`.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ API
 
    * **readDebugNames**: `boolean`<br />
      Reads textual names from the name section.
-   * **check:** `boolean`<br/>
+   * **check**: `boolean`<br/>
      Check for invalid modules (default: true).
 
 * **ToTextOptions**<br />

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,9 @@ interface WasmFeatures { // see: https://github.com/WebAssembly/wabt/blob/main/s
 interface ReadWasmOptions {
   /** Reads textual names from the name section. */
   readDebugNames?: boolean;
+
+  /** Check for invalid modules (default is true). */
+  check?: boolean;
 }
 
 /** Options modifying the behavior of `WasmModule#toText`. */

--- a/tests/index.js
+++ b/tests/index.js
@@ -31,6 +31,24 @@ require("..")().then(wabt => {
     test.end();
   });
 
+  test("loading an invalid binary module", function (test) {
+    var buffer = new Uint8Array(
+      fs.readFileSync(__dirname + "/assembly/module-features.wasm")
+    );
+    buffer[buffer.length - 1] = 0x00; // corrupt the last byte
+    test.throws(function() {
+      mod = wabt.readWasm(buffer, {});
+    }, /function body must end with END opcode/);
+    // Specifying `check: true` allows an invalid module to be loaded.
+    test.doesNotThrow(function() {
+      mod = wabt.readWasm(buffer, {
+        check: false
+      });
+    });
+    test.ok(mod && typeof mod.toBinary === "function", "should return a module");
+    test.end();
+  });
+
   test("modifying a module", function(test) {
     test.doesNotThrow(function() {
       mod.generateNames();


### PR DESCRIPTION
The latest nightly includes a new option in wasm2wat — you can pass `check: false` to allow invalid modules to be loaded, similar to passing `--no-check` in the wasm2wat CLI. Original commit here: https://github.com/WebAssembly/wabt/commit/5fdc74561954b9e9c35877017b31a2be8fff23d1

This PR updates `ReadWasmOptions` to include the new `check` option, and adds a small test.